### PR TITLE
schemas: set cursor-blink to false

### DIFF
--- a/schemas/org.gnome.desktop.interface.gschema.override
+++ b/schemas/org.gnome.desktop.interface.gschema.override
@@ -3,3 +3,4 @@ enable-animations=true
 font-name='Clear Sans 10'
 gtk-theme='Materia'
 icon-theme='Paper'
+cursor-blink=false


### PR DESCRIPTION
Cursor blinks can make an otherwise idle system less so. For that
reason, globally disable cursor blinks for Clear Linux.

End-users are always able to turn cursor blinks back on through the
Universal Access (Accessibility) applet, or through gsettings/dconf.

Signed-off-by: Joe Konno <joe.konno@intel.com>