### PR TITLE
schemas: dash-to-dock: do not animate show-apps

### DIFF
--- a/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.override
+++ b/schemas/org.gnome.shell.extensions.dash-to-dock.gschema.override
@@ -1,4 +1,5 @@
 [org.gnome.shell.extensions.dash-to-dock]
+animate-show-apps=false
 apply-custom-theme=false
 click-action='minimize-or-overview'
 custom-background-color=false


### PR DESCRIPTION
The animation for showing all applications can be costly and/or slow,
depending on the underlying platform. For Clear Linux, disable
animate-show-apps by default. End-users can change this default through
the gnome-tweaks applet or through gsettings/dconf.

Caveat: this does not impact the Show Applications animation when it's
clicked in the Activities view.

Signed-off-by: Joe Konno <joe.konno@intel.com>