### PR TITLE
schemas: impatience: remove overrides

### DIFF
--- a/schemas/org.gnome.shell.extensions.net.gfxmonk.impatience.gschema.override
+++ b/schemas/org.gnome.shell.extensions.net.gfxmonk.impatience.gschema.override
@@ -1,2 +1,0 @@
-[org.gnome.shell.extensions.net.gfxmonk.impatience]
-speed-factor=0.55


### PR DESCRIPTION
Setting speed-factor to 0.55 does not "look good" to my eye. In order
for the animation to appear smooth, the underlying animation code has to
be optimal. Given the number of gripes I see about Gnome animations on
various forums (and the Gnome bugzilla), I do not see that code as
smooth enough to handle a 0.55 speed factor.

Removing this override returns impatience to its upstream default: 0.75
speed factor (at time of writing). It speeds up the animation, while
still appearing to be "smooth" to my eye.

End-users can change the impatience speed factor through the
gnome-tweaks tool, or through gsettings/dconf. Users can also elect to
disable animations entirely by setting
org.gnome.desktop.interface.enable-animations to false.

Signed-off-by: Joe Konno <joe.konno@intel.com>