### PR TITLE
schemas: more aggressive timeouts for cursor-blink

### DIFF
--- a/schemas/org.gnome.desktop.interface.gschema.override
+++ b/schemas/org.gnome.desktop.interface.gschema.override
@@ -3,3 +3,5 @@ enable-animations=true
 font-name='Clear Sans 10'
 gtk-theme='Materia'
 icon-theme='Paper'
+cursor-blink-timeout=3
+cursor-blink-time=1500


### PR DESCRIPTION
Cursor blinks can make an otherwise idle system less so. For that
reason, be more aggressive about turning off cursor blinks.

End-users can tune cursor blink behavior through the Universal Access
(Accessibility) applet, or through gsettings/dconf.

Signed-off-by: Joe Konno <joe.konno@intel.com>